### PR TITLE
ENG-1384 - Add type validation for detective rules

### DIFF
--- a/apps/server/validate/validate.go
+++ b/apps/server/validate/validate.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"regexp"
 
-	"github.com/streamdal/mono/libs/protos/build/go/protos/shared"
-
 	"github.com/pkg/errors"
 
 	"github.com/streamdal/mono/libs/protos/build/go/protos"
+	"github.com/streamdal/mono/libs/protos/build/go/protos/shared"
+	"github.com/streamdal/mono/libs/protos/build/go/protos/steps"
 )
 
 var (
@@ -228,6 +228,19 @@ func PipelineStep(s *protos.PipelineStep) error {
 
 	if s.GetStep() == nil {
 		return errors.New(".Step cannot be nil")
+	}
+
+	if det := s.GetDetective(); det != nil {
+		switch det.Type {
+		case steps.DetectiveType_DETECTIVE_TYPE_HAS_FIELD:
+			fallthrough
+		case steps.DetectiveType_DETECTIVE_TYPE_IS_TYPE:
+			fallthrough
+		case steps.DetectiveType_DETECTIVE_TYPE_IS_EMPTY:
+			if det.GetPath() == "" {
+				return ErrEmptyField("Detective.Path")
+			}
+		}
 	}
 
 	// OK if OnSuccess and OnFailure are nil/empty; nil/empty == implicit continue

--- a/apps/server/validate/validate_suite_test.go
+++ b/apps/server/validate/validate_suite_test.go
@@ -1,0 +1,13 @@
+package validate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validate Suite")
+}

--- a/apps/server/validate/validate_test.go
+++ b/apps/server/validate/validate_test.go
@@ -1,0 +1,56 @@
+package validate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/streamdal/mono/libs/protos/build/go/protos"
+	"github.com/streamdal/mono/libs/protos/build/go/protos/steps"
+	"github.com/streamdal/server/util"
+)
+
+var _ = Describe("Validate", func() {
+	Context("PipelineStep", func() {
+		It("should require a step", func() {
+			Expect(PipelineStep(nil)).To(Equal(ErrNilInput))
+		})
+
+		It("should require path for certain matcher types", func() {
+
+			types := []steps.DetectiveType{
+				steps.DetectiveType_DETECTIVE_TYPE_HAS_FIELD,
+				steps.DetectiveType_DETECTIVE_TYPE_IS_TYPE,
+				steps.DetectiveType_DETECTIVE_TYPE_IS_EMPTY,
+			}
+
+			for _, t := range types {
+				step := &protos.PipelineStep{
+					Step: &protos.PipelineStep_Detective{
+						Detective: &steps.DetectiveStep{
+							Path:   util.Pointer(""),
+							Args:   []string{},
+							Negate: nil,
+							Type:   t,
+						},
+					},
+				}
+
+				Expect(PipelineStep(step).Error()).To(Equal(ErrEmptyField("Detective.Path").Error()))
+			}
+		})
+
+		It("should NOT require path for most matcher types", func() {
+			step := &protos.PipelineStep{
+				Step: &protos.PipelineStep_Detective{
+					Detective: &steps.DetectiveStep{
+						Path:   util.Pointer(""),
+						Args:   []string{},
+						Negate: nil,
+						Type:   steps.DetectiveType_DETECTIVE_TYPE_HOSTNAME,
+					},
+				},
+			}
+
+			Expect(PipelineStep(step)).To(BeNil())
+		})
+	})
+})

--- a/libs/wasm-transform/README.md
+++ b/libs/wasm-transform/README.md
@@ -46,4 +46,3 @@ string, then make sure to include quotes in the payload ( Ie. `"123"`)
    2. Works ONLY on strings
    3. Will replace 100% of the characters with a sha256 hash
 
-## Use as-is - has not been tested in production :)


### PR DESCRIPTION
* Most rules will now work on the entire payload except for a select few which do not make sense to use without a path