### PR TITLE
fix default sample rate bug

### DIFF
--- a/apps/console/components/modals/tailRateModal.tsx
+++ b/apps/console/components/modals/tailRateModal.tsx
@@ -1,6 +1,5 @@
 import IconX from "tabler-icons/tsx/x.tsx";
 import {
-  defaultTailSampleRate,
   tailEnabledSignal,
   tailPausedSignal,
   tailSamplingSignal,
@@ -11,6 +10,11 @@ import * as z from "zod/index.ts";
 import { opModal } from "../serviceMap/opModalSignal.ts";
 import { validate } from "../form/validate.ts";
 
+export const defaultTailSampleRate = {
+  rate: 25,
+  intervalSeconds: 1,
+};
+
 export const SampleRateSchema = zfd.formData({
   rate: zfd.numeric(z.number().min(1)),
   intervalSeconds: zfd.numeric(z.number().min(1)),
@@ -20,7 +24,7 @@ export const SampleRateSchema = zfd.formData({
       defaultTailSampleRate.rate;
   },
   {
-    message: "Max rate is 25/second",
+    message: `Max rate is ${defaultTailSampleRate.rate}/second`,
     path: ["rate"],
   },
 );

--- a/apps/console/islands/drawer/tail.tsx
+++ b/apps/console/islands/drawer/tail.tsx
@@ -14,6 +14,7 @@ import { longDateFormat } from "../../lib/utils.ts";
 import { tailSocket } from "../../lib/sockets.ts";
 import { Tooltip } from "../../components/tooltip/tooltip.tsx";
 import { initFlowbite } from "flowbite";
+import { defaultTailSampleRate } from "../../components/modals/tailRateModal.tsx";
 
 export const MAX_TAIL_SIZE = 200;
 
@@ -28,11 +29,10 @@ export const tailSignal = signal<TailData[] | null>(
 export const tailSocketSignal = signal<WebSocket | null>(null);
 export const tailEnabledSignal = signal<boolean>(false);
 export const tailPausedSignal = signal<boolean>(false);
-export const defaultTailSampleRate = {
-  rate: 25,
-  intervalSeconds: 1,
-};
-export const tailSamplingSignal = signal<TailSampleRate>(defaultTailSampleRate);
+export const tailSamplingSignal = signal<TailSampleRate>({
+  rate: defaultTailSampleRate.rate,
+  intervalSeconds: defaultTailSampleRate.intervalSeconds,
+});
 export const tailDiffSignal = signal<boolean>(false);
 
 export type TailData = { timestamp: Date; data: string; originalData: string };

--- a/apps/console/lib/tail.ts
+++ b/apps/console/lib/tail.ts
@@ -10,10 +10,8 @@ import * as uuid from "$std/uuid/mod.ts";
 import { effect, signal } from "@preact/signals";
 import { client } from "./grpc.ts";
 import { GRPC_TOKEN } from "./configs.ts";
-import {
-  defaultTailSampleRate,
-  TailSampleRate,
-} from "../islands/drawer/tail.tsx";
+import { TailSampleRate } from "../islands/drawer/tail.tsx";
+import { defaultTailSampleRate } from "../components/modals/tailRateModal.tsx";
 
 export const tailAbortSignal = signal<boolean>(false);
 


### PR DESCRIPTION
Passing the default sample object ref to the preact signal meant the defaults themselves were being mutated.