### PR TITLE
ENG-1462: console pipeline crud bugs

### DIFF
--- a/apps/console/components/form/formTextArea.tsx
+++ b/apps/console/components/form/formTextArea.tsx
@@ -9,6 +9,7 @@ export type FormInputProps = {
   errors: ErrorType;
   inputClass?: string;
   wrapperClass?: string;
+  value?: string;
   rows?: number;
 };
 
@@ -21,9 +22,10 @@ export const FormTextArea = ({
   placeHolder,
   inputClass,
   wrapperClass,
+  value,
   rows = 5,
 }: FormInputProps) => {
-  const value = resolveValue(data, name);
+  const v = value || resolveValue(data, name);
 
   return (
     <div class={`flex flex-col my-2 ${wrapperClass}`}>
@@ -44,7 +46,7 @@ export const FormTextArea = ({
         }px] border-${
           errors[name] ? "streamdalRed" : "border-twilight"
         } ${inputClass}`}
-        value={value}
+        value={v}
         onChange={(e) =>
           updateData(
             data,

--- a/apps/console/components/modals/manageOpPipelines.tsx
+++ b/apps/console/components/modals/manageOpPipelines.tsx
@@ -2,6 +2,7 @@ import { PipelineInfo } from "streamdal-protos/protos/sp_info.ts";
 import IconPlus from "tabler-icons/tsx/plus.tsx";
 import { opModal } from "../serviceMap/opModalSignal.ts";
 import { PipelineActionMenu } from "../operation/pipelineActionMenu.tsx";
+import { tailEnabledSignal } from "../../islands/drawer/tail.tsx";
 
 export const ManageOpPipelines = (
   { pipelines }: { Pipelines: PipelineInfo[] },
@@ -22,7 +23,10 @@ export const ManageOpPipelines = (
             <PipelineActionMenu audience={audience} pipeline={pipeline} />
           ))}
           <div class="flex items-center justify-center hover:bg-purple-100 py-3">
-            <a href="/pipelines/add">
+            <a
+              href="/pipelines/add"
+              onClick={() => tailEnabledSignal.value = false}
+            >
               <div
                 class={"flex justify-between items-center text-streamdalPurple font-semibold"}
               >

--- a/apps/console/islands/pipelineSchemaValidation.tsx
+++ b/apps/console/islands/pipelineSchemaValidation.tsx
@@ -1,13 +1,6 @@
 import { ErrorType } from "../components/form/validate.ts";
 import { FormSelect, optionsFromEnum } from "../components/form/formSelect.tsx";
-import {
-  TransformTruncateType,
-  TransformType,
-} from "streamdal-protos/protos/steps/sp_steps_transform.ts";
 import { PipelineStep } from "streamdal-protos/protos/sp_pipeline.ts";
-import { FormInput } from "../components/form/formInput.tsx";
-import { FormBoolean } from "../components/form/formBoolean.tsx";
-import { FormNInput } from "../components/form/formNInput.tsx";
 import {
   JSONSchemaDraft,
   SchemaValidationType,
@@ -28,6 +21,17 @@ export const SchemaValidationOptions = (
   const type = step.step?.schemaValidation?.type ||
     SchemaValidationType.JSONSCHEMA;
 
+  //
+  // Backend sends us the schema as Uint8Array
+  // so we decode it on the fly for display
+  const value =
+    step.step?.schemaValidation?.options?.jsonSchema?.jsonSchema instanceof
+        Uint8Array
+      ? new TextDecoder().decode(
+        step.step?.schemaValidation?.options?.jsonSchema?.jsonSchema,
+      )
+      : step.step?.schemaValidation?.options?.jsonSchema?.jsonSchema;
+
   switch (Number(type)) {
     case SchemaValidationType.JSONSCHEMA:
       return (
@@ -44,6 +48,7 @@ export const SchemaValidationOptions = (
             label="Schema"
             placeHolder="paste your schema here"
             errors={errors}
+            value={value}
           />
           <FormSelect
             name={`steps.${stepNumber}.step.schemaValidation.options.jsonSchema.draft`}

--- a/apps/console/islands/pipelineTransform.tsx
+++ b/apps/console/islands/pipelineTransform.tsx
@@ -8,6 +8,7 @@ import { PipelineStep } from "streamdal-protos/protos/sp_pipeline.ts";
 import { FormInput } from "../components/form/formInput.tsx";
 import { FormBoolean } from "../components/form/formBoolean.tsx";
 import { FormNInput } from "../components/form/formNInput.tsx";
+import IconInfoCircle from "tabler-icons/tsx/info-circle.tsx";
 
 export type PipelineTransformType = {
   stepNumber: number;
@@ -162,7 +163,7 @@ export const TransformOptions = (
           />
           <FormBoolean
             name={`steps.${stepNumber}.step.transform.options.extractOptions.flatten`}
-            display="Flatten"
+            display="Flatten result object"
             defaultChecked={step?.step?.transform?.options
               ?.extractOptions?.flatten}
           />
@@ -184,15 +185,26 @@ export const PipelineTransform = (
 ) => {
   return (
     <>
-      <FormSelect
-        name={`steps.${stepNumber}.step.transform.type`}
-        label="Transform Type"
-        data={data}
-        setData={setData}
-        errors={errors}
-        inputClass="w-64"
-        children={optionsFromEnum(TransformType)}
-      />
+      <div class="flex flex-row justify-start items-center">
+        <FormSelect
+          name={`steps.${stepNumber}.step.transform.type`}
+          label="Transform Type"
+          data={data}
+          setData={setData}
+          errors={errors}
+          inputClass="w-64"
+          children={optionsFromEnum(TransformType)}
+        />
+
+        {Number(step?.step?.transform?.type) === TransformType.EXTRACT
+          ? (
+            <div class="h-[47px] mt-3 ml-2 flex flex-row items-center text-stormCloud text-sm">
+              <IconInfoCircle class="w-5 h-5 mr-1" />
+              Take only selected paths, drop all others
+            </div>
+          )
+          : ""}
+      </div>
       <TransformOptions
         stepNumber={stepNumber}
         step={step}


### PR DESCRIPTION
FIxes a bunch of stuff we saw at today's demo including: 

* transform result "flatten" -> "flatten result object"
* tail modal covers pipeline modal
* newly created pipelines can't be attached
* add tooltip to extract to explain what it does
* decode schema validation text