### PR TITLE
meta cleanup and remove debug logging

### DIFF
--- a/apps/console/islands/notification.tsx
+++ b/apps/console/islands/notification.tsx
@@ -13,11 +13,8 @@ import {
   NotificationType,
 } from "streamdal-protos/protos/sp_notify.ts";
 import { InlineInput } from "../components/form/inlineInput.tsx";
-import IconX from "tabler-icons/tsx/x.tsx";
-import { logFormData } from "../lib/utils.ts";
 import { NotificationMenu } from "../components/notifications/notificationMenu.tsx";
 import { initFlowbite } from "flowbite";
-import { PipelineStep } from "streamdal-protos/protos/sp_pipeline.ts";
 
 const NotificationTypeEnum = z.nativeEnum(NotificationType);
 const EmailNotificationTypeEnum = z.nativeEnum(NotificationEmail_Type);

--- a/apps/console/islands/pipeline.tsx
+++ b/apps/console/islands/pipeline.tsx
@@ -29,7 +29,7 @@ import {
   kvModeFromEnum,
   optionsFromEnum,
 } from "../components/form/formSelect.tsx";
-import { isNumeric, logFormData } from "../lib/utils.ts";
+import { isNumeric } from "../lib/utils.ts";
 import { InlineInput } from "../components/form/inlineInput.tsx";
 import {
   argTypes,
@@ -352,7 +352,6 @@ const PipelineDetail = (
 
   const onSubmit = async (e: any) => {
     const formData = new FormData(e.target);
-    logFormData(formData);
     const { errors } = validate(pipelineSchema, formData);
     setErrors(errors || {});
 

--- a/apps/console/routes/_app.tsx
+++ b/apps/console/routes/_app.tsx
@@ -17,16 +17,11 @@ export default async function App(
     <html lang="en">
       <Head>
         <title>
-          {DEMO === "true"
-            ? "Streamdal: Open Source Data Observability That Drives Action"
-            : "Streamdal Console"}
+          {"Streamdal: the open source code-native data pipeline platform"}
         </title>
         <meta
           charSet="UTF-8"
-          content={DEMO === "true"
-            ? "Detect and resolve data incidents faster by peeking into data flowing through your systems" +
-              " and act on it in real-time with Streamdal"
-            : "Streamdal's Console"}
+          content={"Use Streamdal to build code-native data pipelines that detect and mask PII"}
           name="description"
         />
         {DEMO === "true" &&


### PR DESCRIPTION
I noticed our expanded previews on demo console posts in socials have less than helpful metadata:

<img width="225" alt="Screenshot 2024-01-18 at 10 32 22 AM" src="https://github.com/streamdal/streamdal/assets/191780/eabd704b-979d-4d8c-8009-df3f390e7088">
