### PR TITLE
ENG-1470 - Pipeline transform mask value not used

### DIFF
--- a/.github/workflows/libs-wasm-pr.yml
+++ b/.github/workflows/libs-wasm-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'libs/wasm/**'
+      - 'libs/wasm-detective/**'
+      - 'libs/wasm-transform/**'
       - '.github/workflows/libs-wasm-pr.yml'
 
 defaults:

--- a/.github/workflows/libs-wasm-release.yml
+++ b/.github/workflows/libs-wasm-release.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'libs/wasm/**'
+      - 'libs/wasm-detective/**'
+      - 'libs/wasm-transform/**'
       - '.github/workflows/libs-wasm-release.yml'
 
 defaults:

--- a/libs/wasm-transform/src/transform.rs
+++ b/libs/wasm-transform/src/transform.rs
@@ -427,7 +427,7 @@ pub fn mask(req: &Request) -> Result<String, TransformError> {
             }
             gjson::Kind::Number => {
                 let mut mask_char = req.value.chars().next().unwrap_or('0');
-                if mask_char.is_ascii_alphabetic() {
+                if !mask_char.is_ascii_digit() {
                     mask_char = '0';
                 }
 


### PR DESCRIPTION
* Use mask value
* Add guard for masking numbers
* Update github actions to build wasm when wasm-transform or wasm-detective are updated since we are using relative imports now for those libs