### PR TITLE
Dselans/server ordered pipelines

### DIFF
--- a/apps/server/test-utils/demo-client/demo.go
+++ b/apps/server/test-utils/demo-client/demo.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -234,8 +235,9 @@ func (r *Demo) display(pre []byte, post *streamdal.ProcessResponse, err error) {
 	underline := color.New(color.Underline).SprintFunc()
 
 	var (
-		status  string
-		message string
+		status   string
+		message  string
+		metadata string
 	)
 
 	switch post.Status {
@@ -283,6 +285,22 @@ func (r *Demo) display(pre []byte, post *streamdal.ProcessResponse, err error) {
 	tw.AppendRow(gopretty.Row{bold("Date"), now})
 	tw.AppendRow(gopretty.Row{bold("Status"), status})
 	tw.AppendRow(gopretty.Row{bold("Message"), message})
+
+	// Cleaner metadata
+	metadata = fmt.Sprintf("Total: %d Contents: ", len(post.Metadata))
+
+	if len(post.Metadata) == 0 {
+		metadata = metadata + "none"
+	} else {
+		for k, v := range post.Metadata {
+			metadata = metadata + fmt.Sprintf("'%s' => '%s', ", k, v)
+		}
+
+		metadata = strings.TrimSuffix(metadata, ", ")
+		metadata = metadata + ""
+	}
+
+	tw.AppendRow(gopretty.Row{bold("Metadata"), metadata})
 
 	if !r.config.Quiet {
 		tw.AppendSeparator()

--- a/apps/server/test-utils/demo-client/vendor/github.com/streamdal/go-sdk/register.go
+++ b/apps/server/test-utils/demo-client/vendor/github.com/streamdal/go-sdk/register.go
@@ -286,6 +286,8 @@ func (s *Streamdal) attachPipeline(_ context.Context, cmd *protos.Command) error
 		return ErrEmptyCommand
 	}
 
+	s.config.Logger.Warnf("Received attach pipeline command for audience '%s', pipeline name '%s'", audToStr(cmd.Audience), cmd.GetAttachPipeline().Pipeline.Name)
+
 	s.pipelinesMtx.Lock()
 	defer s.pipelinesMtx.Unlock()
 
@@ -308,7 +310,6 @@ func (s *Streamdal) attachPipeline(_ context.Context, cmd *protos.Command) error
 	if pipelineIndex == -1 {
 		// Pipeline does not exist, append it
 		s.config.Logger.Debugf("Attached new pipeline %s", cmd.GetAttachPipeline().Pipeline.Id)
-
 		s.pipelines[audToStr(cmd.Audience)] = append(s.pipelines[audToStr(cmd.Audience)], cmd)
 	} else {
 		// Avoid potential panic

--- a/apps/server/util/util.go
+++ b/apps/server/util/util.go
@@ -288,7 +288,7 @@ func GenInferSchemaPipeline(aud *protos.Audience) *protos.Command {
 			AttachPipeline: &protos.AttachPipelineCommand{
 				Pipeline: &protos.Pipeline{
 					Id:   GenerateUUID(),
-					Name: "Schema Inference",
+					Name: "Schema Inference (Auto)",
 					Steps: []*protos.PipelineStep{
 						{
 							Name: "Infer Schema",


### PR DESCRIPTION
# WIP

changes include:

1. GetAttachPipelines() injects schema inference pipeline for unique
   audiences
2. Started updates to AttachPipeline() but realized it might need to be
   changed to use Broadcast() instead of sending directly to ch. Will
discuss with @blinktag.
3. Think we still need to detach schema inference pipeline when final
   pipeline is detached? Discuss with Mark