### PR TITLE
fix tag creation for protos and console

### DIFF
--- a/.github/workflows/apps-console-release.yml
+++ b/.github/workflows/apps-console-release.yml
@@ -51,6 +51,7 @@ jobs:
         id: create_tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "apps/console/v"
 
       - name: Set up QEMU

--- a/.github/workflows/libs-protos-release.yml
+++ b/.github/workflows/libs-protos-release.yml
@@ -52,6 +52,7 @@ jobs:
         id: create_tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "libs/protos/v"
 
       - name: Release on crates.io


### PR DESCRIPTION
discovered issue where dry_run was actually causing the next "create tag" action to also bump - meaning that Cargo.toml would contain correct tag but the actual tag we create in GH would be +1'd.

This fixes it for apps/console and libs/protos.

For apps/console, it injects the "dry_run" tag into VERSION but the tag it actually creates for the release was ALSO being bumped.

For protos, the new version is injected into Cargo.toml but because we generated a tag again, it would get bumped again on release. Basically, you'd expect that Cargo.toml version would be the same as the tag but the tag would end up being newer.

<img width="1127" alt="image" src="https://github.com/streamdal/streamdal/assets/1938759/fda15f22-87ae-4b76-a319-854779732d60">