### PR TITLE
use commit sha

### DIFF
--- a/.github/workflows/apps-console-release.yml
+++ b/.github/workflows/apps-console-release.yml
@@ -43,6 +43,7 @@ jobs:
           echo ${{ steps.get_new_version.outputs.new_version }} > VERSION
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit
         with:
           commit_message: Bumped Console VERSION file to ${{ steps.get_new_version.outputs.new_version }}
 
@@ -50,6 +51,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         id: create_tag
         with:
+          commit_sha: ${{ steps.auto_commit.outputs.commit_hash }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "apps/console/v"

--- a/.github/workflows/libs-protos-release.yml
+++ b/.github/workflows/libs-protos-release.yml
@@ -43,6 +43,7 @@ jobs:
 
       # Commit the updated Cargo.toml
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit
         with:
           commit_message: Bumped Cargo.toml version to ${{ steps.get_new_version.outputs.new_version }}
 
@@ -51,6 +52,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         id: create_tag
         with:
+          commit_sha: ${{ steps.auto_commit.outputs.commit_hash }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "libs/protos/v"

--- a/.github/workflows/sdks-go-release.yml
+++ b/.github/workflows/sdks-go-release.yml
@@ -33,6 +33,7 @@ jobs:
           sed -i 's/LibraryVersion:.*/LibraryVersion: "${{ steps.get_new_version.outputs.new_version }}",/' register.go
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit
         with:
           commit_message: Bumped version in register.go to ${{ steps.get_new_version.outputs.new_version }}
 
@@ -41,6 +42,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         id: create_tag
         with:
+          commit_sha: ${{ steps.auto_commit.outputs.commit_hash }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "sdks/go/v"

--- a/.github/workflows/sdks-python-release.yml
+++ b/.github/workflows/sdks-python-release.yml
@@ -34,6 +34,7 @@ jobs:
           sed -i "s/version=.*/version='${{ steps.get_new_version.outputs.new_version }}',/" setup.py
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit
         with:
           commit_message: Bumped version in setup.py to ${{ steps.get_new_version.outputs.new_version }}
 
@@ -42,6 +43,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         id: create_tag
         with:
+          commit_sha: ${{ steps.auto_commit.outputs.commit_hash }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.get_new_version.outputs.new_version }}
           tag_prefix: "sdks/python/v"


### PR DESCRIPTION
Tag creation action was using the _original_ commit sha for the tag and NOT the latest tag (the one from the commit bump). This caused the tag to point to a commit that didn't have the "bump". I don't know if this caused anything to break but if anything was reading those config files with versions, it would 100% get the wrong info. This fixes that.