### PR TITLE
fix slowness with lots of pipelines

### DIFF
--- a/apps/console/components/modals/manageOpPipelines.tsx
+++ b/apps/console/components/modals/manageOpPipelines.tsx
@@ -15,39 +15,37 @@ export const ManageOpPipelines = (
   return (
     audience
       ? (
-        <div>
-          <div class="w-full bg-purple-50 divide-gray-100 max-h-[400px] overflow-auto rounded">
-            <ul
-              class="text-sm text-gray-700 divide-y"
-              aria-labelledby="dropdownDefaultButton"
-            >
-              {sorted.map(({ pipeline }: PipelineInfo) => (
-                pipeline
-                  ? (
-                    <PipelineActionMenu
-                      audience={audience}
-                      pipeline={pipeline}
-                    />
-                  )
-                  : null
-              ))}
-              <div class="flex items-center justify-center hover:bg-purple-100 py-3">
-                <a
-                  href="/pipelines/add"
-                  onClick={() => tailEnabledSignal.value = false}
+        <div class="w-full bg-purple-50 divide-gray-100 max-h-[260px] overflow-auto rounded">
+          <ul
+            class="text-sm text-gray-700 divide-y"
+            aria-labelledby="dropdownDefaultButton"
+          >
+            {sorted.map(({ pipeline }: PipelineInfo) => (
+              pipeline
+                ? (
+                  <PipelineActionMenu
+                    audience={audience}
+                    pipeline={pipeline}
+                  />
+                )
+                : null
+            ))}
+            <div class="flex items-center justify-center hover:bg-purple-100 py-3">
+              <a
+                href="/pipelines/add"
+                onClick={() => tailEnabledSignal.value = false}
+              >
+                <div
+                  class={"flex justify-between items-center text-streamdalPurple font-semibold"}
                 >
-                  <div
-                    class={"flex justify-between items-center text-streamdalPurple font-semibold"}
-                  >
-                    <p class={"text-xs text-streamdalPurple font-semibold"}>
-                      Create new pipeline
-                    </p>
-                    <IconPlus class={"w-3 h-3 ml-3"} />
-                  </div>
-                </a>
-              </div>
-            </ul>
-          </div>
+                  <p class={"text-xs text-streamdalPurple font-semibold"}>
+                    Create new pipeline
+                  </p>
+                  <IconPlus class={"w-3 h-3 ml-3"} />
+                </div>
+              </a>
+            </div>
+          </ul>
         </div>
       )
       : null

--- a/apps/console/components/pipeline/stepCondition.tsx
+++ b/apps/console/components/pipeline/stepCondition.tsx
@@ -4,7 +4,7 @@ import { FormBoolean } from "../form/formBoolean.tsx";
 import { RadioGroup } from "../form/radioGroup.tsx";
 import IconInfoCircle from "tabler-icons/tsx/info-circle.tsx";
 import { Tooltip } from "../tooltip/tooltip.tsx";
-import { useLayoutEffect, useState } from "preact/hooks";
+import { useState } from "preact/hooks";
 import IconChevronUp from "tabler-icons/tsx/chevron-up.tsx";
 import IconChevronDown from "tabler-icons/tsx/chevron-down.tsx";
 import { FormStringKV } from "../form/formStringKV.tsx";
@@ -22,11 +22,6 @@ export const StepCondition = (
   { name, label, toolTip, data, setData, errors }: StepConditionType,
 ) => {
   const [expanded, setExpanded] = useState(false);
-
-  useLayoutEffect(async () => {
-    const { initFlowbite } = await import("flowbite");
-    initFlowbite();
-  });
 
   return (
     <div
@@ -81,7 +76,6 @@ export const StepCondition = (
         <FormStringKV
           name={`${name}.metadata`}
           data={data}
-          setData={setData}
           label={"Metadata"}
           description="Metadata are arbitrary keys and values that will be emitted to calling code"
           errors={errors}

--- a/apps/console/islands/drawer/infoDrawer.tsx
+++ b/apps/console/islands/drawer/infoDrawer.tsx
@@ -15,6 +15,7 @@ import { ResumePipelineModal } from "../../components/modals/resumePipelineModal
 import { AttachPipelineModal } from "../../components/modals/attachPipelineModal.tsx";
 import { Audience } from "https://deno.land/x/streamdal_protos@v0.0.126/protos/sp_common.ts";
 import { TailRateModal } from "../../components/modals/tailRateModal.tsx";
+import { useLayoutEffect } from "preact/hooks";
 
 export const OP_MODAL_WIDTH = "308px";
 
@@ -85,6 +86,11 @@ export const InfoDrawer = (
   { serviceMap }: { serviceMap: ServiceSignal | null },
 ) => {
   const audience = opModal.value?.audience;
+  useLayoutEffect(async () => {
+    const { initFlowbite } = await import("flowbite");
+    initFlowbite();
+  });
+
   return (
     <>
       <Toast id="pipelineCrud" />

--- a/apps/console/islands/drawer/operation.tsx
+++ b/apps/console/islands/drawer/operation.tsx
@@ -60,7 +60,7 @@ export default function Operation(
             </h3>
             <div
               id="collapse-body-1"
-              class={`px-4 py-2 border-b border-purple-100 ${
+              class={`p-2 border-b border-purple-100 ${
                 managePipelines ? "" : "hidden"
               }`}
               aria-labelledby="collapse-heading-1"

--- a/apps/console/islands/pipelineActionMenu.tsx
+++ b/apps/console/islands/pipelineActionMenu.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "../components/tooltip/tooltip.tsx";
 import IconAdjustmentsHorizontal from "tabler-icons/tsx/adjustments-horizontal.tsx";
 import { Audience } from "streamdal-protos/protos/sp_common.ts";
 import { audienceKey } from "../lib/utils.ts";
-import { useEffect, useLayoutEffect, useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 
 import { serviceSignal } from "../components/serviceMap/serviceSignal.ts";
 import { Pipeline } from "streamdal-protos/protos/sp_pipeline.ts";
@@ -110,11 +110,6 @@ export const PipelineActionMenu = (
   const p = serviceSignal.value?.configs[key]?.configs?.find((p) =>
     p.id === pipeline.id
   );
-
-  useLayoutEffect(async () => {
-    const { initFlowbite } = await import("flowbite");
-    initFlowbite();
-  });
 
   return (
     <div

--- a/apps/console/routes/_layout.tsx
+++ b/apps/console/routes/_layout.tsx
@@ -9,7 +9,6 @@ import { CustomError } from "../components/error/custom.tsx";
 import { Partial } from "$fresh/runtime.ts";
 import { InfoDrawer } from "../islands/drawer/infoDrawer.tsx";
 import { Sockets } from "../islands/sockets.tsx";
-import { Tooltip } from "../components/tooltip/tooltip.tsx";
 
 const tokenError = () => (
   <CustomError


### PR DESCRIPTION
We were re-initializing flowbite on every pipeline entry in the info drawer. I moved that up so it only get initialized once there. This seems to have addressed the performance issues. 