### PR TITLE
go-sdk: Bump protos version

### DIFF
--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
 	github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d
-	github.com/streamdal/streamdal/libs/protos v0.1.25
+	github.com/streamdal/streamdal/libs/protos v0.1.27
 	github.com/tetratelabs/wazero v1.6.0
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.60.1

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -38,8 +38,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/streamdal/streamdal/libs/protos v0.1.25 h1:46432kOVj9kuO8gA45d9Q0WpHjlpjamwaPNV+3C3Xvc=
-github.com/streamdal/streamdal/libs/protos v0.1.25/go.mod h1:WZ6qCqzJu/9Vn+P5EUMN1hcOWlxN2EHgcsxehylhgJQ=
+github.com/streamdal/streamdal/libs/protos v0.1.27 h1:b5EAetPWjWrqkOK7XJOPDdUHa11MvqMr9WyUvkPSkEg=
+github.com/streamdal/streamdal/libs/protos v0.1.27/go.mod h1:WZ6qCqzJu/9Vn+P5EUMN1hcOWlxN2EHgcsxehylhgJQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
This includes the new PII matcher types