### PR TITLE
add a .Close() method to SDK interface

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,7 +1,7 @@
 Streamdal Go SDK
 ================
 [![Release](https://github.com/streamdal/streamdal/actions/workflows/sdks-go-release.yml/badge.svg)](https://github.com/streamdal/streamdal/actions/workflows/sdks-go-release.yml)
-[![Pull Request](https://github.com/streamdal/streamdal/actions/workflows/sdks-go-detective-pr.yml/badge.svg)](https://github.com/streamdal/streamdal/blob/main/.github/workflows/sdks-go-detective-pr.yml)
+[![Pull Request](https://github.com/streamdal/streamdal/actions/workflows/sdks-go-pr.yml/badge.svg)](https://github.com/streamdal/streamdal/blob/main/.github/workflows/sdks-go-pr.yml)
 [![Discord](https://img.shields.io/badge/Community-Discord-4c57e8.svg)](https://discord.gg/streamdal)
 
 <!-- TODO: UPDATE CODECLIMATE, GOREPORTCARD LINKS -->
@@ -93,7 +93,7 @@ order to support 12-Factor and usage of this SDK inside shims where `streamdal.C
 | DryRun           | STREAMDAL_DRY_RUN          | If true, no data will be modified                                                | *false*       |
 | Logger           |                            | An optional custom logger                                                        |               |
 | ClientType       |                            | 1 = ClientTypeSDK, 2 = ClientTypeShim                                            | ClientTypeSDK |
-| ShutdownCtx      | -                          | Your application's main context which will receive shutdown signals              |               |
+| ShutdownCtx      | -                          | Optional context used by lib to detect shutdowns              |      *empty*         |
 
 ### Metrics
 

--- a/sdks/go/register.go
+++ b/sdks/go/register.go
@@ -161,6 +161,8 @@ func (s *Streamdal) register(looper director.Looper) error {
 		)
 	}
 
+	s.config.Logger.Debug("register() exit")
+
 	return nil
 }
 


### PR DESCRIPTION
@blinktag

It is possible to `stop` and `resume` plumber relays so SDK needs to have a way to stop all running goroutines etc.

Did a local functional test (watching logs after stop/resume via plumber - saw that metrics and register stops sending requests to server).