### PR TITLE
Add support for resource requests/limits in all pod objects

### DIFF
--- a/docs/install/helm/streamdal-server/templates/deployment.yaml
+++ b/docs/install/helm/streamdal-server/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
             - name: envoy
               containerPort: 8083
               protocol: TCP
+          resources:
+            {{- toYaml .Values.envoy.resources | nindent 12}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/docs/install/helm/streamdal-server/templates/streamdal-console-deployment.yaml
+++ b/docs/install/helm/streamdal-server/templates/streamdal-console-deployment.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
           - mountPath: /root/.cache
             name: esbuild-cache
+          resources:
+            {{- toYaml .Values.console.resources | nindent 12 }}
       volumes:
       - name: esbuild-cache
         emptyDir: {}

--- a/docs/install/helm/streamdal-server/templates/tests/test-connection.yaml
+++ b/docs/install/helm/streamdal-server/templates/tests/test-connection.yaml
@@ -12,4 +12,11 @@ spec:
       image: busybox
       command: ['wget']
       args: ['{{ include "streamdal.fullname" . }}:{{ .Values.service.port }}']
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
   restartPolicy: Never

--- a/docs/install/helm/streamdal-server/values.yaml
+++ b/docs/install/helm/streamdal-server/values.yaml
@@ -128,3 +128,30 @@ consoleIngress:
 redis:  
   auth:
     enabled: false
+
+envoy:
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+console:
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  


### PR DESCRIPTION
Adds support for resource requests and limits in the streamdal console and envoy pods, as well as the test pod.  Some clusters have admission controllers that prevent admission if these are not explicitly stated, resulting in an error like this:

```
Error creating: admission webhook "validation.gatekeeper.sh" denied the request: [container-must-have-limits] container <streamdal-console> has no resource limits
[container-must-meet-ratio] container <streamdal-console> has no resource limits
[container-must-meet-ratio] container <streamdal-console> has no resource requests
[container-must-have-requests] container <streamdal-console> has no resource requests
```