### PR TITLE
ENG-1751 - go-sdk: Process sampling

### DIFF
--- a/sdks/go/audience.go
+++ b/sdks/go/audience.go
@@ -9,6 +9,14 @@ import (
 	"github.com/streamdal/streamdal/libs/protos/build/go/protos"
 )
 
+// Audience is used to announce an audience to the Streamdal server on library initialization
+// We use this to avoid end users having to import our protos
+type Audience struct {
+	ComponentName string
+	OperationType OperationType
+	OperationName string
+}
+
 func (s *Streamdal) addAudience(ctx context.Context, aud *protos.Audience) {
 	// Don't need to add twice
 	if s.seenAudience(ctx, aud) {
@@ -110,5 +118,14 @@ func strToAud(str string) *protos.Audience {
 		ComponentName: parts[1],
 		OperationType: protos.OperationType(opType),
 		OperationName: parts[3],
+	}
+}
+
+func (a *Audience) toProto(serviceName string) *protos.Audience {
+	return &protos.Audience{
+		ServiceName:   strings.ToLower(serviceName),
+		ComponentName: strings.ToLower(a.ComponentName),
+		OperationType: protos.OperationType(a.OperationType),
+		OperationName: strings.ToLower(a.OperationName),
 	}
 }

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
 	github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d
-	github.com/streamdal/streamdal/libs/protos v0.1.54
+	github.com/streamdal/streamdal/libs/protos v0.1.55
 	github.com/tetratelabs/wazero v1.6.0
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.60.1

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -38,8 +38,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/streamdal/streamdal/libs/protos v0.1.54 h1:PX7u3m1wDwZtER77m7YvjRcBWvcKFiaRZ+yN7Xw+uJw=
-github.com/streamdal/streamdal/libs/protos v0.1.54/go.mod h1:1rQ250ydoKeRoJftIV9qGrR28Iqdb9+7Jcnoxber/eQ=
+github.com/streamdal/streamdal/libs/protos v0.1.55 h1:joJ0SiNxlDffaDL8TUVACj/uH6RL5oyA+O92XF/gqv4=
+github.com/streamdal/streamdal/libs/protos v0.1.55/go.mod h1:1rQ250ydoKeRoJftIV9qGrR28Iqdb9+7Jcnoxber/eQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
This PR adds the following config options:
* SamplingEnabled
* SamplingRate
* SamplingIntervalSeconds

If sampling is enabed, the SDK will use the token-bucket algorithm to decide if a message is to be processed. Messages which are not processed are returned with empty PipelineStatus and an ExecStatus of `ExecStatusSkipped`