### PR TITLE
ENG-1752 - Async Mode

### DIFF
--- a/sdks/go/benchmarks_test.go
+++ b/sdks/go/benchmarks_test.go
@@ -207,6 +207,8 @@ func inferSchema(fileName string) (*protos.WASMResponse, error) {
 		pipelines:    map[string][]*protos.Pipeline{},
 		audiencesMtx: &sync.RWMutex{},
 		audiences:    map[string]struct{}{},
+		wasmCacheMtx: &sync.RWMutex{},
+		wasmCache:    map[string][]byte{},
 	}
 
 	f, err := s.createFunction(req.Step)

--- a/sdks/go/go_sdk.go
+++ b/sdks/go/go_sdk.go
@@ -573,7 +573,7 @@ func (s *Streamdal) runStep(ctx context.Context, aud *protos.Audience, step *pro
 	defer f.mtx.Unlock()
 
 	// Don't need this anymore, and don't want to send it to the wasm function
-	step.XWasmBytes = nil
+	//step.XWasmBytes = nil
 
 	req := &protos.WASMRequest{
 		InputPayload:    data,

--- a/sdks/go/go_sdk.go
+++ b/sdks/go/go_sdk.go
@@ -150,6 +150,8 @@ type Streamdal struct {
 	schemas        map[string]*protos.Schema   // k: audienceStr
 	schemasMtx     *sync.RWMutex
 	cancelFunc     context.CancelFunc
+	wasmCache      map[string][]byte
+	wasmCacheMtx   *sync.RWMutex
 
 	// Sampling rate limiter, uses token bucket algo
 	limiter *rate.Limiter
@@ -315,6 +317,8 @@ func New(cfg *Config) (*Streamdal, error) {
 		schemasMtx:     &sync.RWMutex{},
 		schemas:        make(map[string]*protos.Schema),
 		cancelFunc:     cancelFunc,
+		wasmCache:      make(map[string][]byte),
+		wasmCacheMtx:   &sync.RWMutex{},
 	}
 
 	if cfg.DryRun {

--- a/sdks/go/go_sdk.go
+++ b/sdks/go/go_sdk.go
@@ -904,7 +904,7 @@ PIPELINE:
 				// NOT aborting, update LOCAL step & pipeline status
 				s.updateStatus(nil, pipelineStatus, stepStatus)
 
-				s.config.Logger.Warnf("Step '%s:%s' failed (no abort condition defined - continuing step execution)", pipeline.Name, step.Name)
+				s.config.Logger.Warnf("Step '%s:%s' failed (no abort condition defined - continuing step execution): %s", pipeline.Name, step.Name, err.Error())
 
 				continue // Move on to the next step in the pipeline
 			}

--- a/sdks/go/go_sdk_test.go
+++ b/sdks/go/go_sdk_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Streamdal", func() {
 
 	Context("Process", func() {
 		It("return error when process request is nil", func() {
-			s := &Streamdal{}
+			s := &Streamdal{config: &Config{Mode: ModeSync}}
 			resp := s.Process(context.Background(), nil)
 
 			Expect(resp.Status).To(Equal(protos.ExecStatus_EXEC_STATUS_ERROR))
@@ -310,7 +310,7 @@ var _ = Describe("Streamdal", func() {
 		It("fails to process when closed property is set", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			s := &Streamdal{cancelFunc: cancel}
+			s := &Streamdal{cancelFunc: cancel, config: &Config{Mode: ModeSync}}
 			s.Close()
 
 			resp := s.Process(ctx, &ProcessRequest{
@@ -554,6 +554,7 @@ func createStreamdalClientFull(serviceName string, aud *protos.Audience, pipelin
 			Logger:          &logger.TinyLogger{},
 			StepTimeout:     time.Millisecond * 10,
 			PipelineTimeout: time.Millisecond * 100,
+			Mode:            ModeSync,
 		},
 		metrics:      &metricsfakes.FakeIMetrics{},
 		tails:        map[string]map[string]*Tail{},

--- a/sdks/go/go_sdk_test.go
+++ b/sdks/go/go_sdk_test.go
@@ -549,6 +549,8 @@ func createStreamdalClientFull(serviceName string, aud *protos.Audience, pipelin
 		functions:    map[int]map[string]*function{},
 		audiencesMtx: &sync.RWMutex{},
 		audiences:    map[string]struct{}{},
+		wasmCacheMtx: &sync.RWMutex{},
+		wasmCache:    map[string][]byte{},
 		config: &Config{
 			ServiceName:     serviceName,
 			Logger:          &logger.TinyLogger{},
@@ -586,6 +588,8 @@ func createStreamdalClient() (*Streamdal, *kv.KV, error) {
 		audiences:    map[string]struct{}{},
 		kv:           kvClient,
 		hf:           hfClient,
+		wasmCacheMtx: &sync.RWMutex{},
+		wasmCache:    map[string][]byte{},
 	}, kvClient, nil
 }
 

--- a/sdks/go/go_sdk_test.go
+++ b/sdks/go/go_sdk_test.go
@@ -546,7 +546,7 @@ func createStreamdalClientFull(serviceName string, aud *protos.Audience, pipelin
 	return &Streamdal{
 		serverClient: &serverfakes.FakeIServerClient{},
 		functionsMtx: &sync.RWMutex{},
-		functions:    map[string]*function{},
+		functions:    map[int]map[string]*function{},
 		audiencesMtx: &sync.RWMutex{},
 		audiences:    map[string]struct{}{},
 		config: &Config{

--- a/sdks/go/wasm_test.go
+++ b/sdks/go/wasm_test.go
@@ -44,6 +44,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			f, err = s.createFunction(req.Step)
@@ -113,6 +115,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			f, err := s.createFunction(req.Step)
@@ -175,6 +179,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			f, err = s.createFunction(req.Step)
@@ -266,6 +272,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			req = &protos.WASMRequest{
@@ -500,6 +508,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			f, err = s.createFunction(req.Step)
@@ -584,6 +594,8 @@ var _ = Describe("WASM Modules", func() {
 				pipelines:    map[string][]*protos.Pipeline{},
 				audiencesMtx: &sync.RWMutex{},
 				audiences:    map[string]struct{}{},
+				wasmCacheMtx: &sync.RWMutex{},
+				wasmCache:    map[string][]byte{},
 			}
 
 			f, err = s.createFunction(req.Step)


### PR DESCRIPTION
`Config` now accepts the following parameters:
* `Mode` - Either `ModeSync` or `ModeAsync`
* `ModeAsyncNumWorkers` - an integer defining the number of goroutine workers that will execute requests sent to `Process()`

WASM bytes are now cached in a SDK-wide cache so that multiple instances can be created, even after the bytes are wiped from the pipeline steps during first instantiation