### PR TITLE
Dselans/go sdk wazero 1.7.2

### DIFF
--- a/.github/workflows/sdks-go-pr.yml
+++ b/.github/workflows/sdks-go-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.19' # The Go version to download (if necessary) and use.
+          go-version: '~1.22' # The Go version to download (if necessary) and use.
 
       - name: Test
         run: |

--- a/.github/workflows/sdks-go-pr.yml
+++ b/.github/workflows/sdks-go-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.19' # The Go version to download (if necessary) and use.
+          go-version: '~1.20' # The Go version to download (if necessary) and use.
 
       - name: Test
         run: |

--- a/.github/workflows/sdks-go-pr.yml
+++ b/.github/workflows/sdks-go-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.22' # The Go version to download (if necessary) and use.
+          go-version: '~1.19' # The Go version to download (if necessary) and use.
 
       - name: Test
         run: |

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -83,6 +83,8 @@ func main() {
 All configuration can be passed via `streamdal.Config{}`. Some values can be set via environment variables in 
 order to support 12-Factor and usage of this SDK inside shims where `streamdal.Config{}` cannot be set.
 
+NOTE: For the most up to date config options, refer to [go_sdk.go:Config](./go_sdk.go).
+
 | Config Parameter | Environment Variable       | Description                                                                      | Default       |
 |------------------|----------------------------|----------------------------------------------------------------------------------|---------------|
 | ServerURL        | STREAMDAL_URL              | URL pointing to your instance of streamdal server's gRPC API. Ex: localhost:8082 | *empty*       |
@@ -109,10 +111,18 @@ Metrics are published to Streamdal server and are available in Prometheus format
 | `streamdal_counter_produce_processed` | Number of payloads processed by the client | `service`, `component_name`, `operation_name`, `pipeline_id`, `pipeline_name` |
 | `streamdal_counter_notify`            | Number of notifications sent to the server | `service`, `component_name`, `operation_name`, `pipeline_id`, `pipeline_name` |
 
+NOTE: Metrics are **required** - they are used by the server and Console for a
+number of different features such as determining whether clients are alive and
+can accept "commands" and Tail requests from the Console or for displaying
+throughput rates for clients in the UI.
+
+You can tune the number of `metrics workers` that the SDK spawns by setting
+`go_sdk.go:Config.MetricsWorkers`.
+
 ## Release
 
-Any push or merge to the `main` branch with any changes in `/sdks/go/*`
-will automatically tag and release a new console version with `sdks/go/vX.Y.Z`.
+Any push or merge to the `main` branch with any changes in `/sdks/go/*` will 
+automatically tag and release a new SDK version with `sdks/go/vX.Y.Z`.
 
 <sub>(1) If you'd like to skip running the release action on push/merge to `main`,
 include `norelease` anywhere in the commit message.</sub>

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d
 	github.com/streamdal/streamdal/libs/protos v0.1.57
-	github.com/tetratelabs/wazero v1.6.0
+	github.com/tetratelabs/wazero v1.7.2
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.60.1
 	google.golang.org/protobuf v1.32.0

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20231212022811-ec68065c825e // indirect
+	github.com/maxbrunsfeld/counterfeiter/v6 v6.8.1 // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -45,6 +45,10 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
 github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
+github.com/tetratelabs/wazero v1.7.1 h1:QtSfd6KLc41DIMpDYlJdoMc6k7QTN246DM2+n2Y/Dx8=
+github.com/tetratelabs/wazero v1.7.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.7.2 h1:1+z5nXJNwMLPAWaTePFi49SSTL0IMx/i3Fg8Yc25GDc=
+github.com/tetratelabs/wazero v1.7.2/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -24,6 +24,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.8.1 h1:NicmruxkeqHjDv03SfSxqmaLuisddudfP3h5wdXFbhM=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.8.1/go.mod h1:eyp4DdUJAKkr9tvxR3jWhw2mDK7CWABMG5r9uyaKC7I=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=
 github.com/onsi/ginkgo/v2 v2.13.2/go.mod h1:XStQ8QcGwLyF4HdfcZB8SFOS/MWCgDuXMSBe6zrvLgM=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
@@ -45,11 +47,11 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
 github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
-github.com/tetratelabs/wazero v1.7.1 h1:QtSfd6KLc41DIMpDYlJdoMc6k7QTN246DM2+n2Y/Dx8=
-github.com/tetratelabs/wazero v1.7.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tetratelabs/wazero v1.7.2 h1:1+z5nXJNwMLPAWaTePFi49SSTL0IMx/i3Fg8Yc25GDc=
 github.com/tetratelabs/wazero v1.7.2/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=

--- a/sdks/go/go_sdk.go
+++ b/sdks/go/go_sdk.go
@@ -80,7 +80,7 @@ const (
 	// NOTE: Metrics are NOT optional. The server uses metrics sent by the SDK
 	// clients to determine if clients are alive, display usage stats and many
 	// other features.
-	DefaultMetricsNumWorkers = 10
+	DefaultMetricsNumWorkers = 1
 
 	// ReconnectSleep determines the length of time the SDK will wait between
 	// reconnect attempts to streamdal server after the streamdal server goes away.

--- a/sdks/go/go_sdk.go
+++ b/sdks/go/go_sdk.go
@@ -153,6 +153,8 @@ type Streamdal struct {
 	cancelFunc     context.CancelFunc
 	wasmCache      map[string][]byte
 	wasmCacheMtx   *sync.RWMutex
+	funcCreateMtx  *sync.Mutex
+	funcCreate     map[string]*sync.Mutex
 
 	// Sampling rate limiter, uses token bucket algo
 	limiter *rate.Limiter
@@ -320,6 +322,10 @@ func New(cfg *Config) (*Streamdal, error) {
 		cancelFunc:     cancelFunc,
 		wasmCache:      make(map[string][]byte),
 		wasmCacheMtx:   &sync.RWMutex{},
+
+		// Used for blocking getFunctionFromCache() calls when a function is being created
+		funcCreate:    make(map[string]*sync.Mutex),
+		funcCreateMtx: &sync.Mutex{},
 	}
 
 	if cfg.DryRun {

--- a/sdks/go/metrics/metrics.go
+++ b/sdks/go/metrics/metrics.go
@@ -35,10 +35,6 @@ const (
 	// A stale counter is one with zero value and last updated time > ReaperTTL
 	defaultReaperTTL = 10 * time.Second
 
-	// defaultWorkerPoolSize is how many counter workers will be spun up.
-	// These workers are responsible for processing the counterIncrCh and counterPublishCh channels
-	defaultWorkerPoolSize = 10
-
 	// serverFlushTimeout is the maximum amount of time to wait before flushing metrics to the server
 	serverFlushTimeout = time.Second * 2
 
@@ -125,6 +121,10 @@ func validateConfig(cfg *Config) error {
 		return ErrMissingShutdownCtx
 	}
 
+	if cfg.WorkerPoolSize < 1 || cfg.WorkerPoolSize > 100 {
+		return errors.New("metrics WorkerPoolSize must be between 1 and 100")
+	}
+
 	applyDefaults(cfg)
 
 	return nil
@@ -141,11 +141,6 @@ func applyDefaults(cfg *Config) {
 
 	if cfg.ReaperTTL == 0 {
 		cfg.ReaperTTL = defaultReaperTTL
-	}
-
-	// Cannot have a worker pool size of 0
-	if cfg.WorkerPoolSize == 0 {
-		cfg.WorkerPoolSize = defaultWorkerPoolSize
 	}
 
 	if cfg.Log == nil {

--- a/sdks/go/metrics/metrics.go
+++ b/sdks/go/metrics/metrics.go
@@ -35,6 +35,10 @@ const (
 	// A stale counter is one with zero value and last updated time > ReaperTTL
 	defaultReaperTTL = 10 * time.Second
 
+	// defaultWorkerPoolSize is how many counter workers will be spun up.
+	// These workers are responsible for processing the counterIncrCh and counterPublishCh channels
+	defaultWorkerPoolSize = 1
+
 	// serverFlushTimeout is the maximum amount of time to wait before flushing metrics to the server
 	serverFlushTimeout = time.Second * 2
 
@@ -121,10 +125,6 @@ func validateConfig(cfg *Config) error {
 		return ErrMissingShutdownCtx
 	}
 
-	if cfg.WorkerPoolSize < 1 || cfg.WorkerPoolSize > 100 {
-		return errors.New("metrics WorkerPoolSize must be between 1 and 100")
-	}
-
 	applyDefaults(cfg)
 
 	return nil
@@ -141,6 +141,11 @@ func applyDefaults(cfg *Config) {
 
 	if cfg.ReaperTTL == 0 {
 		cfg.ReaperTTL = defaultReaperTTL
+	}
+
+	// Cannot have a worker pool size of 0
+	if cfg.WorkerPoolSize == 0 {
+		cfg.WorkerPoolSize = defaultWorkerPoolSize
 	}
 
 	if cfg.Log == nil {

--- a/sdks/go/metrics/metrics.go
+++ b/sdks/go/metrics/metrics.go
@@ -143,6 +143,7 @@ func applyDefaults(cfg *Config) {
 		cfg.ReaperTTL = defaultReaperTTL
 	}
 
+	// Cannot have a worker pool size of 0
 	if cfg.WorkerPoolSize == 0 {
 		cfg.WorkerPoolSize = defaultWorkerPoolSize
 	}

--- a/sdks/go/server/serverfakes/fake_iserver_client.go
+++ b/sdks/go/server/serverfakes/fake_iserver_client.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"sync"
 
+	"github.com/streamdal/streamdal/libs/protos/build/go/protos"
 	"github.com/streamdal/streamdal/sdks/go/server"
 	"github.com/streamdal/streamdal/sdks/go/types"
-	"github.com/streamdal/streamdal/libs/protos/build/go/protos"
 )
 
 type FakeIServerClient struct {

--- a/sdks/go/wasm_test.go
+++ b/sdks/go/wasm_test.go
@@ -269,12 +269,14 @@ var _ = Describe("WASM Modules", func() {
 
 		BeforeEach(func() {
 			s = &Streamdal{
-				pipelinesMtx: &sync.RWMutex{},
-				pipelines:    map[string][]*protos.Pipeline{},
-				audiencesMtx: &sync.RWMutex{},
-				audiences:    map[string]struct{}{},
-				wasmCacheMtx: &sync.RWMutex{},
-				wasmCache:    map[string][]byte{},
+				pipelinesMtx:  &sync.RWMutex{},
+				pipelines:     map[string][]*protos.Pipeline{},
+				audiencesMtx:  &sync.RWMutex{},
+				audiences:     map[string]struct{}{},
+				wasmCacheMtx:  &sync.RWMutex{},
+				wasmCache:     map[string][]byte{},
+				funcCreate:    make(map[string]*sync.Mutex),
+				funcCreateMtx: &sync.Mutex{},
 			}
 
 			req = &protos.WASMRequest{


### PR DESCRIPTION
@blinktag we should definitely talk about this as this is a fairly big change.

This PR contains the following changes:

* **Updated `wazero` from `1.6.0` to `1.7.2`**

> My profiling showed a 50-80% CPU decrease when switching to 1.7.2 - but this brought on another problem - the _initial_ compile time for a wasm module has increased by ~50%.
> 
> This was not immediatelly noticable but your "multi-threading" test caught it. The test launches 100 goroutines to do a `.Process()` on a new wasm bytes. The initial test run seemed to get stuck, like it was blocking. But as it turns out, it wasn't blocking - it was just eating a ton of CPU trying to complete.
> 
> The issue was that since every .Process() saw this wasmbytes for the first time ever (as in, the wasm module wasn't created and cached yet) - there were 100 goroutines trying to create it at the same time.

> What I did was add another level of locks - I create a lock for every WasmID and `createFunction()` and `getFunctionFromCache()` both use it. This ensures that if someone is in the process of creating a function, the `getFunctionFromCache` will block until the function/wasm module is compiled (and added to the cache map).

* **Exposed `MetricsNumWorkers`**

> We were launching 10 which was taking a lot of CPU time. Lowered the default to `1`. Everything seems to work fine with 1 - tested with 100msg/s throughput.

* **Go 1.20**

> Wazero 1.7.2 requires go 1.20 - they follow 2 releases behind current. So 1.20 is as old as we can go. Meaning that SDK users will also need to be on 1.20. Not terrible, not great.

* **The rest**
> The rest is documentation updates.


