### PR TITLE
Fix STREAMDAL_CONSOLE_GRPC_WEB_URL to match service name

### DIFF
--- a/docs/install/helm/streamdal-server/templates/streamdal-console-deployment.yaml
+++ b/docs/install/helm/streamdal-server/templates/streamdal-console-deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - containerPort: 8080
           env:
             - name: STREAMDAL_CONSOLE_GRPC_WEB_URL
-              value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:8083"
+              value: "http://{{ include "streamdal.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8083"
             - name: STREAMDAL_CONSOLE_GRPC_AUTH_TOKEN
               value: {{ .Values.env.STREAMDAL_SERVER_AUTH_TOKEN | quote }}
             - name: STREAMDAL_CONSOLE_DEMO


### PR DESCRIPTION
Currently the `STREAMDAL_CONSOLE_GRPC_WEB_URL` environment variable uses `.Release.Name` to infer the name of the local streamdal service.  However, the streamdal service gets it's name from a helper function:

```
metadata:
  name: {{ include "streamdal.fullname" . }}
```

This results in inconsistencies.  For example, in our environment we end up with the following error:
```
received grpc getAllStream error RpcError: error sending request for url (http://streamdal.plumber.svc.cluster.local:8083/protos.External/GetAllStream): error trying to connect: dns error: failed to lookup address information: Name or service not known
    at https://esm.sh/v132/@protobuf-ts/grpcweb-transport@2.9.4/denonext/grpcweb-transport.mjs:3:2441
    at eventLoopTick (ext:core/01_core.js:168:7) {
  name: "RpcError",
  code: "INTERNAL",
  meta: {},
  methodName: "GetAllStream",
  serviceName: "protos.External"
}
```

This PR updates the name to match the same name the service will have, which will eliminate that inconsistency.

<details>
<summary>example helm diff</summary>

```yaml
❯ helm diff streamdal ./docs/install/helm/streamdal-server -f ~/code/recharge/helm-core/releases/streamdal/default.values.yml -f ~/code/recharge/helm-core/releases/streamdal/stage.values.yml.gotmpl
Command "helm diff" is deprecated, use "helm diff upgrade" instead
plumber, streamdal-server-console, Deployment (apps) has changed:
  # Source: streamdal-server/templates/streamdal-console-deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: streamdal-server-console
    labels:
      helm.sh/chart: streamdal-server-0.1.77
      app.kubernetes.io/name: server
      app.kubernetes.io/instance: streamdal
      app.kubernetes.io/version: "0.0.4"
      app.kubernetes.io/managed-by: Helm
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: server-console
        app.kubernetes.io/instance: streamdal
    template:
      metadata:
        labels:
          app.kubernetes.io/name: server-console
          app.kubernetes.io/instance: streamdal
      spec:
        containers:
          - name: streamdal-console
            image: "streamdal/console:0.0.71" # Fixed the image and tag definition
            ports:
              - containerPort: 8080
            env:
              - name: STREAMDAL_CONSOLE_GRPC_WEB_URL
-               value: "http://streamdal.plumber.svc.cluster.local:8083"
+               value: "http://streamdal-server.plumber.svc.cluster.local:8083"
              - name: STREAMDAL_CONSOLE_GRPC_AUTH_TOKEN
                value: "redacted"
              - name: STREAMDAL_CONSOLE_DEMO
                value: "false"
              - name: STREAMDAL_CONSOLE_SENTRY_KEY
                value: redacted
              - name: STREAMDAL_CONSOLE_GOOGLE_ANALYTICS_KEY
                value: redacted
              - name: STREAMDAL_CONSOLE_SESSION_KEY
                value: redacted
              - name: STREAMDAL_CONSOLE_PORT
                value: "8080"
              - name: STREAMDAL_CONSOLE_PRODUCTION
                value: "true"
            volumeMounts:
            - mountPath: /root/.cache
              name: esbuild-cache
            resources:
              limits:
                cpu: 400m
                memory: 512Mi
              requests:
                cpu: 200m
                memory: 256Mi
        volumes:
        - name: esbuild-cache
          emptyDir: {}
```

</details>